### PR TITLE
[Core] Update to newer OpenAssetIO api

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
 name: Run tests
 
-on:
-  pull_request:
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,19 +1,7 @@
 name: Run tests
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "*.in"
-      - "*.txt"
-
   pull_request:
-    branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "*.in"
-      - "*.txt"
 
 jobs:
   test:
@@ -23,7 +11,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        python-version: [3.9, ]
+        python-version: [3.9]
 
     runs-on: "ubuntu-latest"
 
@@ -35,47 +23,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Clone OpenAssetIO
-        uses: actions/checkout@v2
-        with:
-          repository: OpenAssetIO/OpenAssetIO
-          ref: v1.0.0-alpha.1
-          path: dependencies/OpenAssetIO
-
-      # Don't cache this as python does some system package installs
-      # that won't be cached and it then breaks on the next run.
-      - name: Build OpenAssetIO
-        run: |
-          pip install conan cmake==3.21 ninja==1.10.2.3 cpplint==1.5.5
-          conan profile new default --detect --force
-          conan profile update settings.compiler.libcxx=libstdc++ default
-          conan install --install-folder ~/.conan --build=missing \
-            -c tools.system.package_manager:mode=install \
-            -c tools.system.package_manager:sudo=True \
-             dependencies/OpenAssetIO/resources/build
-          cmake -S dependencies/OpenAssetIO -B build  \
-            --toolchain ~/.conan/conan_paths.cmake \
-            --install-prefix $GITHUB_WORKSPACE/dist
-          cmake --build build --target openassetio-python-py-install
-
-      - name: Clone OpenAssetIO-MediaCreation
-        uses: actions/checkout@v2
-        with:
-          repository: OpenAssetIO/OpenAssetIO-MediaCreation
-          ref: v1.0.0-alpha.1
-          path: dependencies/OpenAssetIO-MediaCreation
-
-      - name: Install dependencies
-        run: |
-          . dist/bin/activate
-          python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov OpenTimelineIO==0.13.0
-          pip install dependencies/OpenAssetIO-MediaCreation
-
       - name: Install Plugin
         run: |
           . dist/bin/activate
-          pip install -e .
+          pip install -e .[dev]
 
       - name: Lint with flake8
         run: |

--- a/README.md
+++ b/README.md
@@ -58,30 +58,18 @@ python -m venv .venv
 . .venv/bin/activate
 ```
 
-### Dependencies
+This project is dependent on :
 
-To use the linker in OpenTimelineIO `openassetio` and
-`openassetio_mediacreation` need to be installed.
+- `opentimelineio`
+- `openassetio`
+- `openassetio_mediacreation`
 
-At present, for OpenAssetIO, we require installation from source of the
-`v0.0.0-alpha.1` tag.
-
-```shell
-mkdir dependencies
-git clone -b v1.0.0-alpha.1 git@github.com:OpenAssetIO/OpenAssetIO.git dependencies/OpenAssetIO
-cmake -S dependencies/OpenAssetIO -B build
-cmake --build build --target openassetio-python-py-install
-. dist/bin activate
-```
-
-The Media Creation library is more straightforward.
+These dependencies, and the plugin itself, can be installed from the
+project root via
 
 ```shell
-git clone -b v1.0.0-alpha.1 git@github.com:OpenAssetIO/OpenAssetIO-MediaCreation
-pip install dependencies/OpenAssetIO-MediaCreation
+pip install -e .
 ```
-
-You will now be in a Python virtual environment with `openassetio` and `openassetio_mediacreation` available.
 
 ### OpenTimelineIO plugin
 
@@ -94,11 +82,12 @@ pip install -e '.[dev]'
 ### Testing
 
 The tests make us of the `BasicAssetLibrary` example manager plugin from
-the OpenAssetIO repository. They include a `pytest` fixture that extends
-the process environment to set the OpenAssetIO plugin search paths to
-the dependencies directory as installed above.
+the OpenAssetIO repository. If `BasicAssetLibrary` is installed into
+your environment, (which it will be if you've installed the dev extras),
+it will be discovered automatically via [importlib](https://docs.python.org/3/library/importlib.html) package discovery.
 
-Running the tests is then as follows:
+Therefore, the tests can be run from the root of the project directory,
+as follows:
 
 ```shell
 pytest tests

--- a/otio_openassetio/operations/openassetio_media_linker.py
+++ b/otio_openassetio/operations/openassetio_media_linker.py
@@ -7,14 +7,14 @@ their target_url is set to a valid entity reference.
 
 from collections import namedtuple
 
-from openassetio import log, Specification
-from openassetio.hostAPI import HostInterface, Session
-from openassetio.pluginSystem import PluginSystemManagerFactory
+from openassetio import log, exceptions, SpecificationBase
+from openassetio.hostApi import HostInterface, ManagerFactory
+from openassetio.pluginSystem import PythonPluginSystemManagerImplementationFactory
 
 
 import openassetio_mediacreation
-from openassetio_mediacreation.trait import ClipTrait
-from openassetio_mediacreation.trait.entity import LocatableContentTrait
+from openassetio_mediacreation.traits.timeline import ClipTrait
+from openassetio_mediacreation.traits.content import LocatableContentTrait
 
 import opentimelineio as otio
 
@@ -44,15 +44,28 @@ def link_media_reference(in_clip, media_linker_argument_map):
     # over time, however this function isn't, so we track a shared
     # session based on the arguments to the media linker.
     session_state = _sessionState(media_linker_argument_map)
-    manager = session_state.session.currentManager()
+    manager = session_state.manager
 
-    if not extract_one(manager.isEntityReference([mr.target_url])):
+    if not manager.isEntityReferenceString(mr.target_url):
         return
+
+    entity_reference = manager.createEntityReference(mr.target_url)
 
     # Update the locale with more information about this call
     # This is perhaps more illustrative than useful at this point.
     context = session_state.context
     ClipTrait(context.locale).setName(in_clip.name)
+
+    # Upon a successful resolve, use the concrete accessors of the trait
+    # as a view on the resolved data to ensure we access the correct
+    # keys/values.
+    def successful_resolve_callback(_, entity_data):
+        locatable = LocatableContentTrait(entity_data)
+        if locatable.isValid():
+            mr.target_url = LocatableContentTrait(entity_data).getLocation()
+
+    def fail_and_throw(_, batch_element_error):
+        raise exceptions.EntityResolutionError(batch_element_error.message, entity_reference)
 
     # In this simple implementation, we only need the URL to the media,
     # so we use the LocatableContentTrait directly. As we don't know the
@@ -60,15 +73,13 @@ def link_media_reference(in_clip, media_linker_argument_map):
     # particular Specification's traits may end up being wrong. By
     # requesting just the specific trait we require, it avoids the
     # manager fetching any data we are not going to use.
-    entity_data = extract_one(
-        manager.resolve(
-            [mr.target_url], {LocatableContentTrait.kId}, context
-        )
+    manager.resolve(
+        [entity_reference],
+        {LocatableContentTrait.kId},
+        context,
+        successful_resolve_callback,
+        fail_and_throw,
     )
-
-    # We then use the concrete accessors of the trait as a view on
-    # the resolved data to ensure we access the correct keys/values.
-    mr.target_url = LocatableContentTrait(entity_data).getLocation()
 
 
 #
@@ -98,42 +109,18 @@ class OTIOHostInterface(HostInterface):
         return "OpenTimelineIO OpenAssetIO Media Linker plugin"
 
 
-class OTIOClipLocale(Specification):
+class OTIOClipLocale(SpecificationBase):
     """
     An OpenAssetIO Locale that represents API calls for a track clip
     """
 
-    kTraitIds = {
+    kTraitSet = {
         # Describe where we are in the OTIO structure a little
-        openassetio_mediacreation.trait.TimelineTrait.kId,
-        openassetio_mediacreation.trait.TrackTrait.kId,
-        openassetio_mediacreation.trait.ClipTrait.kId,
+        openassetio_mediacreation.traits.timeline.TimelineTrait.kId,
+        openassetio_mediacreation.traits.timeline.TrackTrait.kId,
+        openassetio_mediacreation.traits.timeline.ClipTrait.kId,
         "otio",
     }
-
-    def __init__(self):
-        super().__init__(self.kTraitIds)
-
-
-#
-# Helpers
-#
-
-# Until we have singular conveniences in hostAPI.Manager (see
-# https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/107),
-# then we need to unpack the batch result and raise any exceptions
-# returned for our singular reference.
-
-
-def extract_one(results):
-    """
-    A convenience to extract the first result from a batch OpenAssetIO
-    result, raising if it is an exception.
-    """
-    result = results[0]
-    if isinstance(result, Exception):
-        raise result
-    return result
 
 
 #
@@ -147,13 +134,13 @@ def extract_one(results):
 # the same. This is not ideal. The context lifetime should really be
 # tied to each specific Timeline. That is an exercise for another day.
 
-SessionState = namedtuple("SessionState", ("session", "context"))
+SessionState = namedtuple("SessionState", ("manager", "context"))
 
 _last_args = None
 _session_state = None
 
 
-def _sessionState(args: dict) -> Session:
+def _sessionState(args: dict) -> SessionState:
     """
     Returns a SessionState configured for the supplied settings. If the
     settings are the same as the last invocation, the previously
@@ -182,17 +169,24 @@ def _createSessionState(args: dict) -> SessionState:
 
     host = OTIOHostInterface()
     logger = log.SeverityFilter(log.ConsoleLogger())
-    factory = PluginSystemManagerFactory(logger)
+    factory = PythonPluginSystemManagerImplementationFactory(logger)
 
-    session = Session(host, logger, factory)
-    session.useManager(args["identifier"], args.get("settings", {}))
+    # check if raises
+    manager = ManagerFactory.createManagerForInterface(args["identifier"], host, factory, logger)
+    manager.initialize(args["settings"])
+
+    if not manager:
+        raise RuntimeError(
+            "No default manager configured, "
+            f"check ${ManagerFactory.kDefaultManagerConfigEnvVarName}"
+        )
 
     # The lifetime of the context would ideally be tied to each specific
     # call to read_from_string or similar. Maybe we could introspect
     # each clip and see which Timeline it belongs to. This will do for
     # now though and is better than making a context per clip.
-    context = session.createContext()
-    context.access = context.kRead
-    context.locale = OTIOClipLocale()
+    context = manager.createContext()
+    context.access = context.Access.kRead
+    context.locale = OTIOClipLocale.create().traitsData()
 
-    return SessionState(session=session, context=context)
+    return SessionState(manager=manager, context=context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+[build-system]
+requires = [
+  "opentimelineio >= 0.12.0",
+  "setuptools>=65.5.0"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "otio-openassetio"
+version = "0.0.0"
+requires-python = ">=3.7"
+dependencies = [
+    "openassetio >= 1.0.0a7",
+    "openassetio-mediacreation >= 1.0.0a2",
+    "opentimelineio >= 0.12.0"
+    ]
+
+authors = [
+    { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }
+]
+description = """\
+    Adds asset resolution to OpenTimelineIO via the OpenAssetIO API.
+    """
+keywords = ["timeline", "openassetio", "opentimelineio", "media"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Multimedia :: Video :: Display",
+    "Topic :: Multimedia :: Video :: Non-Linear Editor",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Operating System :: POSIX :: Linux ",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+]
+readme = "README.md"
+
+[project.optional-dependencies]
+dev = ["openassetio-manager-bal >= 1.0.0a3",
+       "pytest"
+      ]
+
+[project.urls]
+OpenAssetIO = "https://github.com/OpenAssetIO/OpenAssetIO"
+OpenTimelineIO = "https://github.com/AcademySoftwareFoundation/OpenTimelineIO"
+Source = "https://github.com/OpenAssetIO/otio-openassetio"
+Issues = "https://github.com/OpenAssetIO/otio-openassetio/issues"
+
+[options.extras_require]
+dev = [
+    "black",
+    "pytest",
+    "twine"
+]
+
+# NB: This requires the use of pyproject-flake8
+[tool.flake8]
+max-line-length = 99
+extend-ignore = "E266,"
+
+[tool.pylint.messages_control]
+disable = [
+    "missing-function-docstring"
+]
+
+[tool.pylint.format]
+max-line-length = 99
+
+[tool.black]
+line-length = 99
+target-version = ["py39"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-# Copyright The Foundry Visionmongers Ltd
-# SPDX-License-Identifier: Apache-2.0
-[tool:pytest]
-addopts = -W ignore::DeprecationWarning
-
-[flake8]
-max-line-length: 99

--- a/setup.py
+++ b/setup.py
@@ -2,23 +2,9 @@
 # Copyright The Foundry Visionmongers Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-import io
 import setuptools
 
-with io.open("README.md", "r", encoding="utf-8") as f:
-    long_description = f.read()
-
-
 setuptools.setup(
-    name="otio-openassetio",
-    author="The Foundry Visionmongers Ltd",
-    author_email="tom@foundry.com",
-    version="0.0.0",
-    description="Adds asset resolution to OpenTimelineIO via the OpenAssetIO API",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    # Replace url with your repo
-    url="https://github.com/TheFoundryVisionmnogers/otio-openassetio",
     packages=setuptools.find_packages(),
     entry_points={"opentimelineio.plugins": "otio_openassetio = otio_openassetio"},
     package_data={
@@ -26,19 +12,4 @@ setuptools.setup(
             "plugin_manifest.json",
         ],
     },
-    install_requires=["OpenTimelineIO >= 0.12.0"],
-    extras_require={"dev": ["black", "pytest", "twine"]},
-    classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: Developers",
-        "Topic :: Multimedia :: Video",
-        "Topic :: Multimedia :: Video :: Display",
-        "Topic :: Multimedia :: Video :: Non-Linear Editor",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Operating System :: POSIX :: Linux ",
-        "License :: OSI Approved :: Apache Software License",
-        "Natural Language :: English",
-    ],
 )

--- a/tests/resources/test_entity_library_missing_asset.json
+++ b/tests/resources/test_entity_library_missing_asset.json
@@ -10,17 +10,6 @@
           }
         }
       ]
-    },
-    "asset2": {
-      "versions": [
-        {
-          "traits": {
-            "openassetio-mediacreation:content.LocatableContent": {
-              "location": "file:///asset/2"
-            }
-          }
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
Change over to using the newer openAssetIO library, significantly the callback rather than the direct return.

Integrate the new libraries via changing the the pyproject.toml project specification mechanism, now using pip dependencies.

Signed-off-by: Elliot Morris <elliot.morris@foundry.com>